### PR TITLE
APIM API operation decoupling

### DIFF
--- a/.github/workflows/standard-logic-app-apim-backend-With-Swagger.yml
+++ b/.github/workflows/standard-logic-app-apim-backend-With-Swagger.yml
@@ -117,5 +117,5 @@ jobs:
            apiName=lgsAPISwag
            apimAPIPath=/appapiswg
            apimAPIDisplayName=ApplicationAPISwag
-           apimAPIOperations="[{\"name\":\"Workflow1Op\",\"lgWorkflowName\":\"Workflow1\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"},{\"name\":\"Workflow2Op\",\"lgWorkflowName\":\"Workflow2\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"}]"
+           apimAPIOperations="[{\"name\":\"Workflow1Op\",\"path\":\"/test1/{customerId}\",\"lgWorkflowName\":\"Workflow1\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"},{\"name\":\"Workflow2Op\",\"path\":\"/test2/\",\"lgWorkflowName\":\"Workflow2\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"}]"
          failOnStdErr: false

--- a/.github/workflows/standard-logic-app-apim-backend.yml
+++ b/.github/workflows/standard-logic-app-apim-backend.yml
@@ -110,5 +110,5 @@ jobs:
            apiName=lgsAPI
            apimAPIPath=/appapi
            apimAPIDisplayName=ApplicationAPI
-           apimAPIOperations="[{\"name\":\"w1\",\"displayName\":\"Workflow1\",\"method\":\"GET\",\"lgWorkflowName\":\"Workflow1\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"},{\"name\":\"w2\",\"displayName\":\"Workflow2\",\"method\":\"GET\",\"lgWorkflowName\":\"Workflow2\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"}]"
+           apimAPIOperations="[{\"name\":\"w1\",\"displayName\":\"Workflow1\",\"method\":\"GET\",\"path\":\"/test1/\",\"lgWorkflowName\":\"Workflow1\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"},{\"name\":\"w2\",\"displayName\":\"Workflow2\",\"method\":\"GET\",\"path\":\"/test2/\",\"lgWorkflowName\":\"Workflow2\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"}]"
          failOnStdErr: false

--- a/.github/workflows/standard-logic-app-apim-backend.yml
+++ b/.github/workflows/standard-logic-app-apim-backend.yml
@@ -110,5 +110,5 @@ jobs:
            apiName=lgsAPI
            apimAPIPath=/appapi
            apimAPIDisplayName=ApplicationAPI
-           apimAPIOperations="[{\"name\":\"w1\",\"displayName\":\"Workflow1\",\"method\":\"GET\",\"path\":\"/test1/\",\"lgWorkflowName\":\"Workflow1\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"},{\"name\":\"w2\",\"displayName\":\"Workflow2\",\"method\":\"GET\",\"path\":\"/test2/\",\"lgWorkflowName\":\"Workflow2\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"}]"
+           apimAPIOperations="[{\"name\":\"w1\",\"displayName\":\"Workflow1\",\"method\":\"GET\",\"path\":\"/test1/{customerId}\",\"lgWorkflowName\":\"Workflow1\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"},{\"name\":\"w2\",\"displayName\":\"Workflow2\",\"method\":\"GET\",\"path\":\"/test2/\",\"lgWorkflowName\":\"Workflow2\",\"lgWorkflowTrigger\":\"When_a_HTTP_request_is_received\"}]"
          failOnStdErr: false

--- a/Application/Workflow1/workflow.json
+++ b/Application/Workflow1/workflow.json
@@ -16,7 +16,11 @@
         "triggers": {
             "When_a_HTTP_request_is_received": {
                 "type": "Request",
-                "kind": "Http"
+                "kind": "Http",
+                "inputs": {
+                    "method": "GET",
+                    "relativePath": "/{customerId}"
+                }
             }
         }
     },

--- a/Bicep/API/APIM-Policies/APIMOperationPolicy.xml
+++ b/Bicep/API/APIM-Policies/APIMOperationPolicy.xml
@@ -2,6 +2,7 @@
 <policies>
     <inbound>
         <base />
+        <rewrite-uri template="__uri__" />
         <set-query-parameter name="api-version" exists-action="append">
             <value>__api-version__</value>
         </set-query-parameter>

--- a/Bicep/API/Modules/apimOperation.azuredeploy.bicep
+++ b/Bicep/API/Modules/apimOperation.azuredeploy.bicep
@@ -20,21 +20,21 @@ param operationDisplayName string
 @description('API Operation Method e.g. GET')
 param operationMethod string
 
+@description('API Operation path that will be replaced with backend implementation through policy')
+param operationPath string
+
 @description('Logic App Call Back object containing URL and other details')
 param lgCallBackObject object
 
 // ** Variables **
 // ***************
 
-var operationUrlBase = split(split(lgCallBackObject.value, '?')[0], '/api')[1]
 var hasRelativePath = lgCallBackObject.?relativePath != null ? true : false
 var pathParametersList = hasRelativePath ? lgCallBackObject.relativePathParameters : []
 var pathParameters = [for pathParameter in pathParametersList: {
     name: pathParameter
     type: 'string'
 }]
-var RelativePathHasBeginingSlash = hasRelativePath ? first(lgCallBackObject.relativePath) == '/' : false
-var operationUrl = hasRelativePath && RelativePathHasBeginingSlash ? '${operationUrlBase}${lgCallBackObject.relativePath}' : hasRelativePath && !RelativePathHasBeginingSlash ? '${operationUrlBase}/${lgCallBackObject.relativePath}' : operationUrlBase
 
 // ** Resources **
 // ***************
@@ -45,7 +45,7 @@ resource logicAppAPIGetOperation 'Microsoft.ApiManagement/service/apis/operation
   properties: {
     displayName: operationDisplayName
     method: operationMethod
-    urlTemplate: operationUrl
+    urlTemplate: operationPath
     templateParameters: hasRelativePath ? pathParameters : null
   }
 }

--- a/Bicep/API/Modules/apimOperationPolicy.azuredeploy.bicep
+++ b/Bicep/API/Modules/apimOperationPolicy.azuredeploy.bicep
@@ -14,24 +14,24 @@ param parentStructureForName string
 @description('The raw policy document template')
 param rawPolicy string
 
-@description('The Logic App service API version')
-param apiVersion string
-
-@description('The Logic App workflow permissions')
-param sp string
-
-@description('The Logic App workflow version number of the query parameters')
-param sv string
-
 @description('The named value name for the workflow sig')
 param sig string
+
+@description('Logic App Call Back object containing URL and other details')
+param lgCallBackObject object
 
 // ** Variables **
 // ***************
 
-var policyApiVersion = replace(rawPolicy, '__api-version__', apiVersion)
-var policySP = replace(policyApiVersion, '__sp__', sp)
-var policySV = replace(policySP, '__sv__', sv)
+var operationUrlBase = split(split(lgCallBackObject.value, '?')[0], '/api')[1]
+var hasRelativePath = lgCallBackObject.?relativePath != null ? true : false
+var RelativePathHasBeginingSlash = hasRelativePath ? first(lgCallBackObject.relativePath) == '/' : false
+var operationUrl = hasRelativePath && RelativePathHasBeginingSlash ? '${operationUrlBase}${lgCallBackObject.relativePath}' : hasRelativePath && !RelativePathHasBeginingSlash ? '${operationUrlBase}/${lgCallBackObject.relativePath}' : operationUrlBase
+
+var policyURI = replace(rawPolicy, '__uri__', operationUrl)
+var policyApiVersion = replace(policyURI, '__api-version__', lgCallBackObject.queries['api-version'])
+var policySP = replace(policyApiVersion, '__sp__', lgCallBackObject.queries.sp)
+var policySV = replace(policySP, '__sv__', lgCallBackObject.queries.sv)
 var policySIG = replace(policySV, '__sig__', sig)
 
 

--- a/Bicep/API/logicAppStandardApimAPI.azuredeploy.bicep
+++ b/Bicep/API/logicAppStandardApimAPI.azuredeploy.bicep
@@ -13,6 +13,7 @@ targetScope = 'resourceGroup'
   name: 'Name of the API Operation'
   displayName: 'User friendly name of the API Operation'
   method: 'The API Operations HTTP method'
+  path: 'APIM API Operation path that will be replaced with backend implementation through policy. Relative Paths included and matching Logic App.'
   lgWorkflowName: 'Name of the Standard Logic App Workflow to use for the Operation Backend'
   lgWorkflowTrigger: 'Name of the Workflow HTTP Trigger'
 })
@@ -21,6 +22,7 @@ type apimAPIOperation = {
   name: string
   displayName: string
   method: 'GET' | 'PUT' | 'POST' | 'PATCH' | 'DELETE'
+  path: string
   lgWorkflowName: string
   lgWorkflowTrigger: string
 }
@@ -104,8 +106,8 @@ module logicAppAPIOperation 'Modules/apimOperation.azuredeploy.bicep' = [for ope
     lgCallBackObject: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01')
     operationDisplayName: operation.displayName
     operationMethod: operation.method
+    operationPath: operation.path
     operationName: operation.name
-
   }
 }]
 
@@ -188,9 +190,7 @@ module operationPolicy './Modules/apimOperationPolicy.azuredeploy.bicep' = [for 
   params: {
     parentStructureForName: '${apimInstance.name}/${logicAppAPI.name}/${operation.name}'
     rawPolicy: apimOperationPolicyRaw
-    apiVersion: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01').queries['api-version']
-    sp: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01').queries.sp
-    sv: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01').queries.sv
+    lgCallBackObject: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01')
     sig: '{{${apiName}-${operation.name}-sig}}'
   }
   dependsOn: [

--- a/Bicep/API/logicAppStandardApimAPI.azuredeploy.bicepparam
+++ b/Bicep/API/logicAppStandardApimAPI.azuredeploy.bicepparam
@@ -11,6 +11,7 @@ param apimAPIOperations = [
     name: 'w1'
     displayName: 'Workflow1'
     method: 'GET'
+    path: '/test1/'
     lgWorkflowName: 'Workflow1'
     lgWorkflowTrigger: 'When_a_HTTP_request_is_received'
   }
@@ -18,6 +19,7 @@ param apimAPIOperations = [
     name: 'w2'
     displayName: 'Workflow2'
     method: 'GET'
+    path: '/test2/'
     lgWorkflowName: 'Workflow2'
     lgWorkflowTrigger: 'When_a_HTTP_request_is_received'
   }

--- a/Bicep/API/logicAppStandardApimAPI.azuredeploy.bicepparam
+++ b/Bicep/API/logicAppStandardApimAPI.azuredeploy.bicepparam
@@ -11,7 +11,7 @@ param apimAPIOperations = [
     name: 'w1'
     displayName: 'Workflow1'
     method: 'GET'
-    path: '/test1/'
+    path: '/test1/{customerId}'
     lgWorkflowName: 'Workflow1'
     lgWorkflowTrigger: 'When_a_HTTP_request_is_received'
   }

--- a/Bicep/API/logicAppStandardApimAPIWithSwagger.azuredeploy.bicep
+++ b/Bicep/API/logicAppStandardApimAPIWithSwagger.azuredeploy.bicep
@@ -11,12 +11,14 @@ targetScope = 'resourceGroup'
 @description('Configuration properties for setting up a LG App stnd APIM API Operation')
 @metadata({
   name: 'Name of the API Operation'
+  path: 'APIM API Operation path that will be replaced with backend implementation through policy. Relative Paths included and matching Logic App.'
   lgWorkflowName: 'Name of the Standard Logic App Workflow to use for the Operation Backend'
   lgWorkflowTrigger: 'Name of the Workflow HTTP Trigger'
 })
 @sealed()
 type apimAPIOperation = {
   name: string
+  path: string
   lgWorkflowName: string
   lgWorkflowTrigger: string
 }
@@ -177,9 +179,7 @@ module operationPolicy './Modules/apimOperationPolicy.azuredeploy.bicep' = [for 
   params: {
     parentStructureForName: '${apimInstance.name}/${logicAppAPI.name}/${operation.name}'
     rawPolicy: apimOperationPolicyRaw
-    apiVersion: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01').queries['api-version']
-    sp: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01').queries.sp
-    sv: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01').queries.sv
+    lgCallBackObject: listCallbackUrl(resourceId('Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers', logicAppName, 'runtime', 'workflow', 'management', operation.lgWorkflowName, operation.lgWorkflowTrigger), '2022-09-01')
     sig: '{{${apiName}-${operation.name}-sig}}'
   }
 }]

--- a/Bicep/API/logicAppStandardApimAPIWithSwagger.azuredeploy.bicepparam
+++ b/Bicep/API/logicAppStandardApimAPIWithSwagger.azuredeploy.bicepparam
@@ -9,11 +9,13 @@ param apimAPIDisplayName = 'ApplicationAPI2'
 param apimAPIOperations = [
   {
     name: 'Workflow1Op'
+    path: '/test1/{customerId}'
     lgWorkflowName: 'Workflow1'
     lgWorkflowTrigger: 'When_a_HTTP_request_is_received'
   }
   {
     name: 'Workflow2Op'
+    path: '/test2/'
     lgWorkflowName: 'Workflow2'
     lgWorkflowTrigger: 'When_a_HTTP_request_is_received'
   }

--- a/SwaggerGenerator/ControlFile.json
+++ b/SwaggerGenerator/ControlFile.json
@@ -1,11 +1,13 @@
 [
 	{
 		"OperationName": "Workflow1Op",
+		"Path": "/test1/{customerId}",
 		"WorkflowDefinitionName": "Workflow1",
 		"HTTPTriggerName": "When_a_HTTP_request_is_received"
 	},
 	{
 		"OperationName": "Workflow2Op",
+		"Path": "/test2/",
 		"WorkflowDefinitionName": "Workflow2",
 		"HTTPTriggerName": "When_a_HTTP_request_is_received"
 	}

--- a/SwaggerGenerator/SpecCreator.ps1
+++ b/SwaggerGenerator/SpecCreator.ps1
@@ -196,7 +196,6 @@ foreach ($workflow in $controlData) {
 
 	$triggerMethod = 'get'
 	$relativePath = ''
-	$relativePathBase = "/{0}/triggers/{1}/invoke/" -f $workflow.WorkflowDefinitionName, $workflow.HTTPTriggerName
 	$bodyDescription = ''
 	$pathParametersArray = @()
 	try {
@@ -260,15 +259,11 @@ foreach ($workflow in $controlData) {
 				$pathParametersArray += $parameterString
 			}
 		}
-		$relativePath = (Join-Path -Path $relativePathBase -ChildPath $relativePath).Replace('\', '/')
-	}
-	else {
-		$relativePath = $relativePathBase
 	}
 	
 	$parameters = $pathParametersArray -join ","
 
-	$populatedApiPath = $apiPath -f $relativePath, $triggerMethod.ToLower(), $workflow.OperationName, $parameters
+	$populatedApiPath = $apiPath -f $workflow.Path, $triggerMethod.ToLower(), $workflow.OperationName, $parameters
 	$apiPaths += $populatedApiPath
 
 }


### PR DESCRIPTION
Both API setups did not have the operation path decoupled from the backend URL.

This change allows you to place your own custom incoming Operation Path. Make sure if the Workflow uses relative path parameters to reflect this in your Path config